### PR TITLE
fix(cli): handle empty KMS key ARN from environment variables

### DIFF
--- a/src/gimlet/cli.py
+++ b/src/gimlet/cli.py
@@ -13,8 +13,8 @@ from . import jwt as jwt_utils
 
 def _validate_signing_key_options(private_key_file: Path | None, kms_key_arn: str | None) -> None:
     """Validate that exactly one signing key option is provided."""
-    has_private_key = private_key_file is not None
-    has_kms = kms_key_arn is not None
+    has_private_key = bool(private_key_file)
+    has_kms = bool(kms_key_arn)
 
     if has_private_key and has_kms:
         click.echo("Error: --private-key-file and --kms-key-arn are mutually exclusive", err=True)


### PR DESCRIPTION
## Summary
- Fixes `AttributeError: 'NoneType' object has no attribute 'exists'` when using `--kms-key-arn` with an empty/unset environment variable
- The validation used `is not None` but the conditional used truthiness, causing a mismatch when empty strings were passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)