### PR TITLE
docs: document CheckOrigin security rationale

### DIFF
--- a/src/server/main.go
+++ b/src/server/main.go
@@ -25,6 +25,9 @@ import (
 )
 
 var (
+	// CheckOrigin returns true for all requests because authentication is handled
+	// via JWT tokens in the Authorization header, not via origin checking.
+	// Origin-based security is unnecessary when using bearer token authentication.
 	upgrader = websocket.Upgrader{
 		CheckOrigin: func(r *http.Request) bool { return true },
 	}


### PR DESCRIPTION
## Summary
- Add comment explaining why the WebSocket upgrader's CheckOrigin function returns true
- Clarifies that origin-based security is unnecessary when using JWT bearer token authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)