### PR TITLE
refactor: remove Get prefix from getter methods

### DIFF
--- a/src/agent/connection/handler_test.go
+++ b/src/agent/connection/handler_test.go
@@ -233,7 +233,7 @@ func (m *mockRequestTracker) DecrementRequests() {
 	atomic.AddInt32(&m.count, -1)
 }
 
-func (m *mockRequestTracker) GetCount() int32 {
+func (m *mockRequestTracker) Count() int32 {
 	return atomic.LoadInt32(&m.count)
 }
 
@@ -327,8 +327,8 @@ func TestCancelAfterEndProcessed(t *testing.T) {
 	// Verify request tracker shows 0 in-flight requests
 	// Allow a brief moment for final cleanup
 	time.Sleep(50 * time.Millisecond)
-	if tracker.GetCount() != 0 {
-		t.Errorf("Expected 0 in-flight requests, got %d", tracker.GetCount())
+	if tracker.Count() != 0 {
+		t.Errorf("Expected 0 in-flight requests, got %d", tracker.Count())
 	}
 }
 
@@ -473,8 +473,8 @@ func TestResponseDoneSignalsRequestGoroutine(t *testing.T) {
 	<-handlerDone
 
 	// Verify clean exit
-	if tracker.GetCount() != 0 {
-		t.Errorf("Expected 0 in-flight requests after completion, got %d", tracker.GetCount())
+	if tracker.Count() != 0 {
+		t.Errorf("Expected 0 in-flight requests after completion, got %d", tracker.Count())
 	}
 }
 

--- a/src/server/agentmgr/agent.go
+++ b/src/server/agentmgr/agent.go
@@ -63,8 +63,8 @@ func NewAgent(id, serviceName string, conn protocol.WebSocketConn) *Agent {
 	}
 }
 
-// GetLoad returns the current number of active requests (thread-safe)
-func (a *Agent) GetLoad() int {
+// Load returns the current number of active requests (thread-safe)
+func (a *Agent) Load() int {
 	a.RespLock.Lock()
 	defer a.RespLock.Unlock()
 	return len(a.requests)
@@ -181,8 +181,8 @@ func (a *Agent) SetReady(ready bool) {
 	a.Ready = ready
 }
 
-// GetBufferUsage returns the total number of buffered frames across all active requests
-func (a *Agent) GetBufferUsage() int {
+// BufferUsage returns the total number of buffered frames across all active requests
+func (a *Agent) BufferUsage() int {
 	a.RespLock.Lock()
 	defer a.RespLock.Unlock()
 

--- a/src/server/agentmgr/agent_test.go
+++ b/src/server/agentmgr/agent_test.go
@@ -87,13 +87,13 @@ func (m *MockWebSocketConn) SetWriteDeadline(t time.Time) error {
 	return nil // Mock implementation, no-op for tests
 }
 
-func (m *MockWebSocketConn) GetWriteCalls() []interface{} {
+func (m *MockWebSocketConn) WriteCalls() []interface{} {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return append([]interface{}{}, m.writeCalls...)
 }
 
-func (m *MockWebSocketConn) GetBinaryWrites() [][]byte {
+func (m *MockWebSocketConn) BinaryWrites() [][]byte {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return append([][]byte{}, m.binaryWrites...)

--- a/src/server/handlers/http.go
+++ b/src/server/handlers/http.go
@@ -23,7 +23,7 @@ import (
 
 // AgentProvider provides access to local agents
 type AgentProvider interface {
-	GetLocalAgents() map[string]*agentmgr.Agent
+	LocalAgents() map[string]*agentmgr.Agent
 }
 
 // HTTPHandler handles HTTP requests with streaming responses
@@ -173,7 +173,7 @@ func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.logger.Debug().Str("clientID", clientID).Str("service", service).Msg("Client JWT validated")
 
 	// Select agent (round-robin)
-	allAgents := h.agentProvider.GetLocalAgents()
+	allAgents := h.agentProvider.LocalAgents()
 	type agentEntry struct {
 		id    string
 		agent *agentmgr.Agent

--- a/src/server/handlers/http_integration_test.go
+++ b/src/server/handlers/http_integration_test.go
@@ -25,7 +25,7 @@ type testAgentProvider struct {
 	agents map[string]*agentmgr.Agent
 }
 
-func (m *testAgentProvider) GetLocalAgents() map[string]*agentmgr.Agent {
+func (m *testAgentProvider) LocalAgents() map[string]*agentmgr.Agent {
 	return m.agents
 }
 

--- a/src/server/main.go
+++ b/src/server/main.go
@@ -47,7 +47,7 @@ type Server struct {
 }
 
 // Implement handlers.AgentProvider interface
-func (cs *Server) GetLocalAgents() map[string]*agentmgr.Agent {
+func (cs *Server) LocalAgents() map[string]*agentmgr.Agent {
 	cs.agentsLock.RLock()
 	defer cs.agentsLock.RUnlock()
 
@@ -60,7 +60,7 @@ func (cs *Server) GetLocalAgents() map[string]*agentmgr.Agent {
 }
 
 // Implement metrics.ServerInfo interface
-func (cs *Server) GetAgentCounts() map[string]int {
+func (cs *Server) AgentCounts() map[string]int {
 	cs.agentsLock.RLock()
 	defer cs.agentsLock.RUnlock()
 
@@ -71,26 +71,26 @@ func (cs *Server) GetAgentCounts() map[string]int {
 	return serviceCounts
 }
 
-func (cs *Server) GetActiveRequestCount() int {
+func (cs *Server) ActiveRequestCount() int {
 	cs.agentsLock.RLock()
 	defer cs.agentsLock.RUnlock()
 
 	total := 0
 	for _, ag := range cs.agents {
-		total += ag.GetLoad()
+		total += ag.Load()
 	}
 	return total
 }
 
-func (cs *Server) GetServerID() string {
+func (cs *Server) ServerID() string {
 	return cs.serverID
 }
 
-func (cs *Server) GetStartTime() time.Time {
+func (cs *Server) StartTime() time.Time {
 	return cs.startTime
 }
 
-func (cs *Server) GetAgentBufferStats() []metrics.AgentBufferStat {
+func (cs *Server) AgentBufferStats() []metrics.AgentBufferStat {
 	cs.agentsLock.RLock()
 	defer cs.agentsLock.RUnlock()
 
@@ -99,13 +99,13 @@ func (cs *Server) GetAgentBufferStats() []metrics.AgentBufferStat {
 		stats = append(stats, metrics.AgentBufferStat{
 			Service:     ag.ServiceName,
 			AgentID:     ag.ID,
-			BufferUsage: ag.GetBufferUsage(),
+			BufferUsage: ag.BufferUsage(),
 		})
 	}
 	return stats
 }
 
-func (cs *Server) GetAgentMetrics() []metrics.AgentMetricsSnapshot {
+func (cs *Server) AgentMetrics() []metrics.AgentMetricsSnapshot {
 	cs.agentsLock.RLock()
 	defer cs.agentsLock.RUnlock()
 
@@ -175,7 +175,7 @@ func (cs *Server) logStatsLoop(interval time.Duration) {
 				serviceStats[ag.ServiceName] = map[string]int{"agents": 0, "requests": 0}
 			}
 			serviceStats[ag.ServiceName]["agents"]++
-			serviceStats[ag.ServiceName]["requests"] += ag.GetLoad()
+			serviceStats[ag.ServiceName]["requests"] += ag.Load()
 		}
 
 		activeRequests := 0


### PR DESCRIPTION
## Summary
- Follow Go idiom where simple accessor methods don't use the `Get` prefix
- Renamed methods across `Agent`, `Server`, related interfaces, and test mocks

**Methods renamed:**
- `Agent.GetLoad()` → `Load()`
- `Agent.GetBufferUsage()` → `BufferUsage()`
- `Server.GetLocalAgents()` → `LocalAgents()`
- `Server.GetAgentCounts()` → `AgentCounts()`
- `Server.GetActiveRequestCount()` → `ActiveRequestCount()`
- `Server.GetServerID()` → `ServerID()`
- `Server.GetStartTime()` → `StartTime()`
- `Server.GetAgentBufferStats()` → `AgentBufferStats()`
- `Server.GetAgentMetrics()` → `AgentMetrics()`

**Test mocks:**
- `MockWebSocketConn.GetWriteCalls()` → `WriteCalls()`
- `MockWebSocketConn.GetBinaryWrites()` → `BinaryWrites()`
- `mockRequestTracker.GetCount()` → `Count()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)