### PR TITLE
Add /status endpoint with scope-based JWT authorization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,4 +141,5 @@ gen-jwts: gen-keys
 	@uv run gimlet jwt agent --subject agent-v1-2 --service model-v1 --duration 24h --private-key-file $(CREDS_DIR)/jwt-signing-key.pem > $(CREDS_DIR)/agent-v1-2.jwt
 	@uv run gimlet jwt agent --subject agent-v2-1 --service model-v2 --duration 24h --private-key-file $(CREDS_DIR)/jwt-signing-key.pem > $(CREDS_DIR)/agent-v2-1.jwt
 	@uv run gimlet jwt client --subject test-client --services "*" --duration 24h --private-key-file $(CREDS_DIR)/jwt-signing-key.pem > $(CREDS_DIR)/client.jwt
+	@uv run gimlet jwt client --subject status-client --services "*" --scope status --duration 24h --private-key-file $(CREDS_DIR)/jwt-signing-key.pem > $(CREDS_DIR)/status-client.jwt
 	@echo "✓ JWTs generated in $(CREDS_DIR)/"

--- a/src/gimlet/jwt.py
+++ b/src/gimlet/jwt.py
@@ -83,7 +83,12 @@ def parse_duration(s: str) -> timedelta:
 
 
 def generate_agent_jwt(
-    subject: str, service: str, duration: str, key_path: Path, issuer: str = "gimlet"
+    subject: str,
+    service: str,
+    duration: str,
+    key_path: Path,
+    issuer: str = "gimlet",
+    scopes: list[str] | None = None,
 ) -> str:
     """Generate agent JWT (aud: gimlet-agent)."""
     private_key = load_or_generate_keypair(key_path)
@@ -98,12 +103,19 @@ def generate_agent_jwt(
         "exp": int((now + parse_duration(duration)).timestamp()),
         "nbf": int(now.timestamp()),
     }
+    if scopes:
+        claims["scope"] = scopes
 
     return jwt.encode(claims, private_key, algorithm="RS256")
 
 
 def generate_client_jwt(
-    subject: str, services: list[str], duration: str, key_path: Path, issuer: str = "gimlet"
+    subject: str,
+    services: list[str],
+    duration: str,
+    key_path: Path,
+    issuer: str = "gimlet",
+    scopes: list[str] | None = None,
 ) -> str:
     """Generate client JWT (aud: gimlet-client)."""
     private_key = load_or_generate_keypair(key_path)
@@ -118,6 +130,8 @@ def generate_client_jwt(
         "exp": int((now + parse_duration(duration)).timestamp()),
         "nbf": int(now.timestamp()),
     }
+    if scopes:
+        claims["scope"] = scopes
 
     return jwt.encode(claims, private_key, algorithm="RS256")
 
@@ -220,7 +234,12 @@ def _build_jwt_with_kms(claims: dict, key_arn: str) -> str:
 
 
 def generate_agent_jwt_kms(
-    subject: str, service: str, duration: str, key_arn: str, issuer: str = "gimlet"
+    subject: str,
+    service: str,
+    duration: str,
+    key_arn: str,
+    issuer: str = "gimlet",
+    scopes: list[str] | None = None,
 ) -> str:
     """Generate agent JWT using KMS for signing (aud: gimlet-agent)."""
     now = datetime.now(timezone.utc)
@@ -234,12 +253,19 @@ def generate_agent_jwt_kms(
         "exp": int((now + parse_duration(duration)).timestamp()),
         "nbf": int(now.timestamp()),
     }
+    if scopes:
+        claims["scope"] = scopes
 
     return _build_jwt_with_kms(claims, key_arn)
 
 
 def generate_client_jwt_kms(
-    subject: str, services: list[str], duration: str, key_arn: str, issuer: str = "gimlet"
+    subject: str,
+    services: list[str],
+    duration: str,
+    key_arn: str,
+    issuer: str = "gimlet",
+    scopes: list[str] | None = None,
 ) -> str:
     """Generate client JWT using KMS for signing (aud: gimlet-client)."""
     now = datetime.now(timezone.utc)
@@ -253,5 +279,7 @@ def generate_client_jwt_kms(
         "exp": int((now + parse_duration(duration)).timestamp()),
         "nbf": int(now.timestamp()),
     }
+    if scopes:
+        claims["scope"] = scopes
 
     return _build_jwt_with_kms(claims, key_arn)

--- a/src/server/auth/jwt_test.go
+++ b/src/server/auth/jwt_test.go
@@ -321,6 +321,220 @@ func TestSanitizeJWTError(t *testing.T) {
 	}
 }
 
+func TestHasScope(t *testing.T) {
+	tests := []struct {
+		name     string
+		scopes   []string
+		required string
+		expected bool
+	}{
+		{"present", []string{"status", "metrics"}, "status", true},
+		{"absent", []string{"metrics"}, "status", false},
+		{"empty list", []string{}, "status", false},
+		{"nil list", nil, "status", false},
+		{"exact match only", []string{"status-admin"}, "status", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := HasScope(tt.scopes, tt.required)
+			if result != tt.expected {
+				t.Errorf("HasScope(%v, %q) = %v, want %v", tt.scopes, tt.required, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestValidateScopedJWT_ClientToken(t *testing.T) {
+	privateKey, publicKey := generateTestKeyPair(t)
+	validator := NewJWTValidator([]*rsa.PublicKey{publicKey}, "gimlet-test")
+
+	claims := ClientClaims{
+		Services: []string{"*"},
+		Scopes:   []string{"status"},
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "client-1",
+			Issuer:    "gimlet-test",
+			Audience:  jwt.ClaimStrings{"gimlet-client"},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tokenString, err := token.SignedString(privateKey)
+	if err != nil {
+		t.Fatalf("Failed to sign token: %v", err)
+	}
+
+	subject, err := validator.ValidateScopedJWT(tokenString, "status")
+	if err != nil {
+		t.Fatalf("Expected valid scoped token, got error: %v", err)
+	}
+	if subject != "client-1" {
+		t.Errorf("Expected subject 'client-1', got '%s'", subject)
+	}
+}
+
+func TestValidateScopedJWT_AgentToken(t *testing.T) {
+	privateKey, publicKey := generateTestKeyPair(t)
+	validator := NewJWTValidator([]*rsa.PublicKey{publicKey}, "gimlet-test")
+
+	claims := AgentClaims{
+		Service: "test-service",
+		Scopes:  []string{"status"},
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "agent-1",
+			Issuer:    "gimlet-test",
+			Audience:  jwt.ClaimStrings{"gimlet-agent"},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tokenString, err := token.SignedString(privateKey)
+	if err != nil {
+		t.Fatalf("Failed to sign token: %v", err)
+	}
+
+	subject, err := validator.ValidateScopedJWT(tokenString, "status")
+	if err != nil {
+		t.Fatalf("Expected valid scoped token, got error: %v", err)
+	}
+	if subject != "agent-1" {
+		t.Errorf("Expected subject 'agent-1', got '%s'", subject)
+	}
+}
+
+func TestValidateScopedJWT_MissingScope(t *testing.T) {
+	privateKey, publicKey := generateTestKeyPair(t)
+	validator := NewJWTValidator([]*rsa.PublicKey{publicKey}, "gimlet-test")
+
+	claims := ClientClaims{
+		Services: []string{"*"},
+		Scopes:   []string{"metrics"}, // wrong scope
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "client-1",
+			Issuer:    "gimlet-test",
+			Audience:  jwt.ClaimStrings{"gimlet-client"},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tokenString, _ := token.SignedString(privateKey)
+
+	_, err := validator.ValidateScopedJWT(tokenString, "status")
+	if err == nil {
+		t.Error("Expected error for missing required scope, got nil")
+	}
+}
+
+func TestValidateScopedJWT_NoScopeClaim(t *testing.T) {
+	privateKey, publicKey := generateTestKeyPair(t)
+	validator := NewJWTValidator([]*rsa.PublicKey{publicKey}, "gimlet-test")
+
+	// Token without any scope claim (existing format)
+	claims := ClientClaims{
+		Services: []string{"*"},
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "client-1",
+			Issuer:    "gimlet-test",
+			Audience:  jwt.ClaimStrings{"gimlet-client"},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tokenString, _ := token.SignedString(privateKey)
+
+	_, err := validator.ValidateScopedJWT(tokenString, "status")
+	if err == nil {
+		t.Error("Expected error for token without scope claim, got nil")
+	}
+}
+
+func TestValidateScopedJWT_ExpiredToken(t *testing.T) {
+	privateKey, publicKey := generateTestKeyPair(t)
+	validator := NewJWTValidator([]*rsa.PublicKey{publicKey}, "gimlet-test")
+
+	claims := ClientClaims{
+		Services: []string{"*"},
+		Scopes:   []string{"status"},
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "client-1",
+			Issuer:    "gimlet-test",
+			Audience:  jwt.ClaimStrings{"gimlet-client"},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(-1 * time.Hour)), // expired
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tokenString, _ := token.SignedString(privateKey)
+
+	_, err := validator.ValidateScopedJWT(tokenString, "status")
+	if err == nil {
+		t.Error("Expected error for expired scoped token, got nil")
+	}
+}
+
+func TestValidateScopedJWT_WrongKey(t *testing.T) {
+	privateKey1, _ := generateTestKeyPair(t)
+	_, publicKey2 := generateTestKeyPair(t)
+
+	validator := NewJWTValidator([]*rsa.PublicKey{publicKey2}, "gimlet-test")
+
+	claims := ClientClaims{
+		Services: []string{"*"},
+		Scopes:   []string{"status"},
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "client-1",
+			Issuer:    "gimlet-test",
+			Audience:  jwt.ClaimStrings{"gimlet-client"},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tokenString, _ := token.SignedString(privateKey1)
+
+	_, err := validator.ValidateScopedJWT(tokenString, "status")
+	if err == nil {
+		t.Error("Expected error for wrong signing key, got nil")
+	}
+}
+
+func TestValidateScopedJWT_WrongAudience(t *testing.T) {
+	privateKey, publicKey := generateTestKeyPair(t)
+	validator := NewJWTValidator([]*rsa.PublicKey{publicKey}, "gimlet-test")
+
+	// Use ScopedClaims directly to craft a token with a non-Gimlet audience
+	claims := ScopedClaims{
+		Scopes: []string{"status"},
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "client-1",
+			Issuer:    "gimlet-test",
+			Audience:  jwt.ClaimStrings{"some-other-aud"},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tokenString, _ := token.SignedString(privateKey)
+
+	_, err := validator.ValidateScopedJWT(tokenString, "status")
+	if err == nil {
+		t.Error("Expected error for wrong audience, got nil")
+	}
+}
+
+func TestSanitizeJWTError_InsufficientScope(t *testing.T) {
+	err := fmt.Errorf("missing required scope: status")
+	result := SanitizeJWTError(err)
+	if result != "Insufficient scope" {
+		t.Errorf("Expected 'Insufficient scope', got '%s'", result)
+	}
+}
+
 func TestValidateJWT_MultipleKeys(t *testing.T) {
 	// Test key rotation: validator has multiple keys, token signed with second key
 	privateKey1, publicKey1 := generateTestKeyPair(t)

--- a/src/server/main.go
+++ b/src/server/main.go
@@ -294,7 +294,7 @@ func main() {
 	// Add health and status endpoints to main mux if no separate port configured
 	if cfg.HealthPort == "" {
 		mux.HandleFunc("/health", metrics.HealthHandler(cs))
-		mux.HandleFunc("/status", metrics.StatusHandler(cs))
+		mux.HandleFunc("/status", metrics.StatusHandler(cs, jwtValidator))
 	}
 
 	// Add metrics endpoint to main mux if no separate port configured
@@ -316,7 +316,7 @@ func main() {
 	if cfg.HealthPort != "" {
 		healthMux := http.NewServeMux()
 		healthMux.HandleFunc("/health", metrics.HealthHandler(cs))
-		healthMux.HandleFunc("/status", metrics.StatusHandler(cs))
+		healthMux.HandleFunc("/status", metrics.StatusHandler(cs, jwtValidator))
 		go func() {
 			logger.Info().Str("port", cfg.HealthPort).Msg("Health endpoint listening")
 			if err := http.ListenAndServe(":"+cfg.HealthPort, healthMux); err != nil && err != http.ErrServerClosed {

--- a/src/server/metrics/metrics.go
+++ b/src/server/metrics/metrics.go
@@ -215,6 +215,17 @@ type AgentMetricsSnapshot struct {
 	ConnectionUptimeSeconds int64
 }
 
+// AgentStatusSnapshot holds the status of a single agent for the /status endpoint
+type AgentStatusSnapshot struct {
+	ID                      string    `json:"id"`
+	Ready                   bool      `json:"ready"`
+	ActiveRequests          int       `json:"active_requests"`
+	Draining                bool      `json:"draining"`
+	ConnectionUptimeSeconds int64     `json:"connection_uptime_seconds"`
+	BackendFailures         int64     `json:"backend_failures"`
+	TokenExpiresAt          time.Time `json:"token_expires_at,omitempty"`
+}
+
 // ServerInfo provides server state for health/metrics reporting
 type ServerInfo interface {
 	AgentCounts() map[string]int
@@ -223,6 +234,7 @@ type ServerInfo interface {
 	StartTime() time.Time
 	AgentBufferStats() []AgentBufferStat
 	AgentMetrics() []AgentMetricsSnapshot
+	AgentStatuses() map[string][]AgentStatusSnapshot
 }
 
 // HealthHandler returns a health check endpoint handler
@@ -238,6 +250,43 @@ func HealthHandler(server ServerInfo) http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(health)
+	}
+}
+
+// StatusHandler returns a detailed JSON status endpoint handler
+func StatusHandler(server ServerInfo) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		agentStatuses := server.AgentStatuses()
+
+		// Build per-service summary
+		type serviceStatus struct {
+			AgentCount     int                   `json:"agent_count"`
+			ActiveRequests int                   `json:"active_requests"`
+			Agents         []AgentStatusSnapshot `json:"agents"`
+		}
+
+		services := make(map[string]serviceStatus, len(agentStatuses))
+		for svc, agents := range agentStatuses {
+			svcRequests := 0
+			for _, ag := range agents {
+				svcRequests += ag.ActiveRequests
+			}
+			services[svc] = serviceStatus{
+				AgentCount:     len(agents),
+				ActiveRequests: svcRequests,
+				Agents:         agents,
+			}
+		}
+
+		status := map[string]interface{}{
+			"server_id":       server.ServerID(),
+			"uptime":          time.Since(server.StartTime()).String(),
+			"active_requests": server.ActiveRequestCount(),
+			"services":        services,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(status)
 	}
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,21 @@ def auth_headers(client_jwt):
     return {"Authorization": f"Bearer {client_jwt}"}
 
 
+@pytest.fixture(scope="session")
+def status_jwt():
+    """Load status-scoped client JWT from file."""
+    jwt_path = Path(__file__).parent / "resources" / "credentials" / "status-client.jwt"
+    if not jwt_path.exists():
+        pytest.fail(f"Status JWT not found at {jwt_path}. Run 'make gen-jwts' first.")
+    return jwt_path.read_text().strip()
+
+
+@pytest.fixture(scope="session")
+def status_auth_headers(status_jwt):
+    """Return headers with status-scoped JWT authorization."""
+    return {"Authorization": f"Bearer {status_jwt}"}
+
+
 @pytest.fixture(scope="session", autouse=True)
 def wait_for_services(auth_headers):
     """


### PR DESCRIPTION
## Summary

Adds a new `/status` JSON endpoint that exposes detailed server and agent state, secured behind scope-based JWT authorization. This is a two-part change:

1. **`/status` endpoint** — returns structured JSON with server uptime, active request counts, and per-service agent details (readiness, load, draining state, connection uptime, backend failures, JWT expiry). Registered on both main and health ports.
2. **Scope-based JWT authorization** — an optional `"scope": ["status", ...]` claim can be added to any Gimlet token (agent or client). The `/status` endpoint requires a valid token with the `"status"` scope. Existing tokens without scopes continue working unchanged for their original purposes (agent registration, client requests). `/health` remains unauthenticated.

### What changed

**Status endpoint** (`8444c5c`):
- `AgentStatusSnapshot` struct with per-agent fields: ID, ready, active requests, draining, connection uptime, backend failures, token expiry
- `AgentStatuses()` method on `Server` that collects snapshots under read locks
- `StatusHandler` returning JSON with `server_id`, `uptime`, `active_requests`, and per-service agent breakdowns
- Endpoint registered on both the main mux and the separate health port mux

**Scoped authorization** (`fe562d9`):
- `ScopedClaims` type and `HasScope()` helper in `auth/jwt.go`
- `ValidateScopedJWT(token, requiredScope)` — validates any Gimlet token (agent or client audience) and checks that the required scope is present. Separate from `ValidateAgentJWT`/`ValidateClientJWT` so it doesn't affect normal request flow.
- `StatusHandler` now requires `Authorization: Bearer <token>` with the `status` scope — returns 401 with sanitized errors otherwise
- `SanitizeJWTError` handles scope-related errors ("Insufficient scope")

**CLI & token generation**:
- `gimlet jwt agent` and `gimlet jwt client` accept a new `--scope` flag (repeatable) to embed scopes into generated tokens
- All 4 JWT generation functions (local key + KMS, agent + client) support the optional `scopes` parameter
- `make gen-jwts` generates a `status-client.jwt` for E2E tests

**Tests**:
- 8 new Go unit tests: `HasScope` (5 cases), `ValidateScopedJWT` with valid client/agent tokens, missing scope, no scope claim, expired token, wrong key, wrong audience, error sanitization
- 4 new E2E tests: `/status` returns 401 without auth, 401 with unscoped token, 200 with scoped token, `/health` regression guard
- pytest fixtures for `status_jwt` and `status_auth_headers`

### Files changed

| File | Change |
|------|--------|
| `src/server/metrics/metrics.go` | Add `AgentStatusSnapshot`, `AgentStatuses` interface method, `StatusHandler` with Bearer token + scope validation |
| `src/server/main.go` | Implement `AgentStatuses()` on `Server`, register `/status` on both muxes, pass `jwtValidator` to `StatusHandler` |
| `src/server/auth/jwt.go` | Add `ScopedClaims` type, `HasScope()` helper, `ValidateScopedJWT()` method, sanitize scope errors |
| `src/server/auth/jwt_test.go` | 8 new test cases covering scope validation |
| `src/gimlet/jwt.py` | Add optional `scopes` param to all 4 JWT generation functions |
| `src/gimlet/cli.py` | Add `--scope` option to `agent` and `client` subcommands |
| `tests/conftest.py` | Add `status_jwt` and `status_auth_headers` session fixtures |
| `tests/test_auth.py` | 4 new E2E tests for `/status` auth and `/health` regression guard |
| `Makefile` | Generate `status-client.jwt` in `gen-jwts` target |

## Test plan

- [ ] `make test-go` — unit tests for `HasScope`, `ValidateScopedJWT` (8 cases covering valid client/agent tokens, missing scope, no scope claim, expired, wrong key, wrong audience, error sanitization)
- [ ] `make test-e2e` — E2E tests verify `/status` returns 401 without auth, 401 with unscoped token, 200 with scoped token, and `/health` remains open
- [ ] Verify existing agent/client auth is unaffected (no changes to `ValidateAgentJWT`/`ValidateClientJWT`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)